### PR TITLE
docs(readme): add instructions for downloading and running nightly builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,26 @@ cargo build --release
 
 The `sp` binary will be at `target/release/sp`. Add it to your `PATH`.
 
+
+-----
+
+## 📥 Using the Latest Nightly Build
+
+You can download the latest nightly build from [`actions/workflows/rust.yml`](actions/workflows/rust.yml) inside this repository (select a successful build and scroll down to `Artifacts`).
+
+Before running the downloaded binary, remove the quarantine attribute:
+
+```sh
+xattr -d com.apple.quarantine ./sp
+```
+
+Then, you can run the binary directly:
+
+```sh
+./sp --help
+```
+
+
 -----
 
 ## 🤝 Contributing


### PR DESCRIPTION
Include section on downloading latest nightly builds from `.github/actions/workflows/rust.yml`. Add note for removing quarantine attribute before execution.